### PR TITLE
fix(create): Throw an error if no code is given

### DIFF
--- a/src/methods/create.ts
+++ b/src/methods/create.ts
@@ -11,7 +11,10 @@ type Code = {
 
 export default async (file: Code) => {
     let uri = "https://api.srcshare.io/code";
-    if(file.code) throw new Error("You need to give some code to upload first!")
+    
+    if(!file.code) 
+        throw new Error("You need to give some code to upload first!");
+    
     if (file.language && file.language === "html")
         file.language = "html/xml";
 


### PR DESCRIPTION
You had 

```js
if (file.code) throw new Error();
```

Instead of 

```js
if (!file.code) throw new Error();
```